### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,5 +21,5 @@ Add as an input in your nix configuration flake, and add as an overlay to nixpkg
 
 You can then keep it up to date by running 
 ```
-$ nix flake lock --update-input encore
+$ nix flake update encore
 ```


### PR DESCRIPTION
As you can see in the screenshot, the other nix command to update the encore flake was deprecated.

![image](https://github.com/user-attachments/assets/02db561b-4dc0-43e7-88b1-65ddd72b70e9)
