### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,39 @@ Add as an input in your nix configuration flake
 ```nix
 {
   inputs = {
+    # other inputs...
+    encore = {
+      url = "github:encoredev/encore-flake";
+      # optional
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+}
+```
+
+### Only the CLI
+
+Import `encore.packages.default` into your nixos configuration
+
+```nix
+# Home manager
+home.packages = [
+  inputs.encore.packages.${pkgs.system}.encore
+];
+
+# NixOS configuration
+environment.systemPackages = [
+  inputs.encore.packages.${pkgs.system}.encore
+];
+```
+
+### In a Development Shell
+
+Add a `flake.nix` file in to your Encore project directory and include it in the available commands for that project/directory using the `outputs` function.
+
+```nix
+{
+  inputs = {
     nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils"
     encore = {
@@ -39,26 +72,11 @@ Add as an input in your nix configuration flake
             # other outputs...
           ];
        };
-     });
-  };
+     });  
 }
 ```
 
-### Only the CLI
-
-Import `encore.packages.default` into your nixos configuration
-
-```nix
-# Home manager
-home.packages = [
-  inputs.encore.packages.${pkgs.system}.encore
-];
-
-# NixOS configuration
-environment.systemPackages = [
-  inputs.encore.packages.${pkgs.system}.encore
-];
-```
+then run `nix develop` to enter the development shell for that project directory.
 
 ### With Home manager
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Add a `flake.nix` file in to your Encore project folder and include `encore` in 
 }
 ```
 
-then run `nix develop`from the project folder to enter the development shell for your project that will now include the `encore` CLI in the tool chain.
+then run `nix develop` from the project folder to enter the development shell for your project that will now include the `encore` CLI in the tool chain.
 
 ### With Home manager
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ environment.systemPackages = [
 
 ### In a Development Shell
 
-Add a `flake.nix` file in to your Encore project directory and include it in the available commands for that project/directory using the `outputs` function.
+Add a `flake.nix` file in to your Encore project folder and include `encore` in the available command line tools for that project/folder using the `outputs` function.
 
 ```nix
 {
@@ -76,7 +76,7 @@ Add a `flake.nix` file in to your Encore project directory and include it in the
 }
 ```
 
-then run `nix develop` to enter the development shell for that project directory.
+then run `nix develop`from the project folder to enter the development shell for your project that will now include the `encore` CLI in the tool chain.
 
 ### With Home manager
 

--- a/README.md
+++ b/README.md
@@ -15,12 +15,31 @@ Add as an input in your nix configuration flake
 ```nix
 {
   inputs = {
-    # other inputs...
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils"
     encore = {
       url = "github:encoredev/encore-flake";
       # optional
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    # other inputs...
+  };
+
+  outputs = { self, nixpkgs, flake-utils, encore, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+        encorePkg = encore.packages.${system}.default;
+      in {
+        devShells.default = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            encorePkg
+            git
+            go
+            # other outputs...
+          ];
+       };
+     });
   };
 }
 ```


### PR DESCRIPTION
export the encore CLI to the develop shell in the readme.md

```bash
nix develop
```

will launch a new shell for development with all required CLI tools available, and getting encore in to the outputs is not as straight forward as it may seem for newcomers.

Since the flake itself is so new, there is not a lot of sample configurations around, and this is the one place developers will expect to see a working sample.