### PR TITLE
Add missing dependencies for autoPatchelfHook

### DIFF
--- a/encore.nix
+++ b/encore.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, autoPatchelfHook }:
+{ stdenv, lib, fetchurl, autoPatchelfHook, libtiff }:
 let
   release = import ./release.nix;
 in
@@ -26,7 +26,10 @@ stdenv.mkDerivation rec
     autoPatchelfHook
   ];
 
-  buildInputs = [ ];
+  buildInputs = [
+    stdenv.cc.cc.lib
+    libtiff
+  ];
 
   unpackPhase = ''
     tar -C ./ -xzf ${src}


### PR DESCRIPTION
Since the last version, nix can't build the package.

Build error logs:

```text
error: builder for '/nix/store/plm9hkm5s8zs4x41784snidgywmbimm4-encore-1.46.21.drv' failed with exit code 1;
       last 25 log lines:
       > skipping /nix/store/z433b881jbl4sp5anzi0212xqcmn5886-encore-1.46.21/encore-go/src/debug/elf/testdata/go-relocation-test-gcc620-sparc64.obj because it contains no segment
       > skipping /nix/store/z433b881jbl4sp5anzi0212xqcmn5886-encore-1.46.21/encore-go/src/debug/elf/testdata/go-relocation-test-gcc482-ppc64le.obj because it contains no segment
       > setting interpreter of /nix/store/z433b881jbl4sp5anzi0212xqcmn5886-encore-1.46.21/encore-go/src/debug/elf/testdata/gcc-amd64-linux-exec
       > searching for dependencies of /nix/store/z433b881jbl4sp5anzi0212xqcmn5886-encore-1.46.21/encore-go/src/debug/elf/testdata/gcc-amd64-linux-exec
       > skipping /nix/store/z433b881jbl4sp5anzi0212xqcmn5886-encore-1.46.21/encore-go/src/debug/elf/testdata/compressed-32.obj because it contains no segment
       > skipping /nix/store/z433b881jbl4sp5anzi0212xqcmn5886-encore-1.46.21/encore-go/src/debug/elf/testdata/compressed-64.obj because it contains no segment
       > skipping /nix/store/z433b881jbl4sp5anzi0212xqcmn5886-encore-1.46.21/encore-go/src/debug/elf/testdata/zdebug-test-gcc484-x86-64.obj because it contains no segment
       > skipping /nix/store/z433b881jbl4sp5anzi0212xqcmn5886-encore-1.46.21/encore-go/src/debug/elf/testdata/go-relocation-test-gcc492-arm.obj because it contains no segment
       > skipping /nix/store/z433b881jbl4sp5anzi0212xqcmn5886-encore-1.46.21/encore-go/src/debug/elf/testdata/go-relocation-test-clang-x86.obj because it contains no segment
       > searching for dependencies of /nix/store/z433b881jbl4sp5anzi0212xqcmn5886-encore-1.46.21/encore-go/src/debug/elf/testdata/libtiffxx.so_
       >     libtiff.so.6 -> not found!
       >     libstdc++.so.6 -> not found!
       > skipping /nix/store/z433b881jbl4sp5anzi0212xqcmn5886-encore-1.46.21/encore-go/src/debug/elf/testdata/gcc-amd64-openbsd-debug-with-rela.obj because it contains no segment
       > searching for dependencies of /nix/store/z433b881jbl4sp5anzi0212xqcmn5886-encore-1.46.21/encore-go/src/debug/elf/testdata/go-relocation-test-gcc930-ranges-with-rela-x86-64
       > skipping /nix/store/z433b881jbl4sp5anzi0212xqcmn5886-encore-1.46.21/encore-go/src/debug/elf/testdata/go-relocation-test-gcc5-ppc.obj because it contains no segment
       > skipping /nix/store/z433b881jbl4sp5anzi0212xqcmn5886-encore-1.46.21/encore-go/src/debug/elf/testdata/go-relocation-test-gcc531-s390x.obj because it contains no segment
       > skipping /nix/store/z433b881jbl4sp5anzi0212xqcmn5886-encore-1.46.21/encore-go/src/debug/elf/testdata/go-relocation-test-gcc540-mips.obj because it contains no segment
       > skipping /nix/store/z433b881jbl4sp5anzi0212xqcmn5886-encore-1.46.21/encore-go/src/crypto/internal/boring/syso/goboringcrypto_linux_arm64.syso because it contains no segment
       > skipping /nix/store/z433b881jbl4sp5anzi0212xqcmn5886-encore-1.46.21/encore-go/src/crypto/internal/boring/syso/goboringcrypto_linux_amd64.syso because it contains no segment
       > searching for dependencies of /nix/store/z433b881jbl4sp5anzi0212xqcmn5886-encore-1.46.21/runtimes/js/encore-runtime.node
       > auto-patchelf: 2 dependencies could not be satisfied
       > error: auto-patchelf could not satisfy dependency libtiff.so.6 wanted by /nix/store/z433b881jbl4sp5anzi0212xqcmn5886-encore-1.46.21/encore-go/src/debug/elf/testdata/libtiffxx.so_
       > error: auto-patchelf could not satisfy dependency libstdc++.so.6 wanted by /nix/store/z433b881jbl4sp5anzi0212xqcmn5886-encore-1.46.21/encore-go/src/debug/elf/testdata/libtiffxx.so_
       > auto-patchelf failed to find all the required dependencies.
       > Add the missing dependencies to --libs or use `--ignore-missing="foo.so.1 bar.so etc.so"`.
       For full logs, run:
         nix log /nix/store/plm9hkm5s8zs4x41784snidgywmbimm4-encore-1.46.21.drv
```

This will solve it :)