### PR TITLE
fix encore build for macos

### DIFF
--- a/encore.nix
+++ b/encore.nix
@@ -22,11 +22,11 @@ stdenv.mkDerivation rec
 
   dontBuild = true;
 
-  nativeBuildInputs = [
+  nativeBuildInputs = lib.optionals stdenv.isLinux [
     autoPatchelfHook
   ];
 
-  buildInputs = [
+  buildInputs = lib.optionals stdenv.isLinux [
     stdenv.cc.cc.lib
     libtiff
   ];


### PR DESCRIPTION
This pull request updates the `encore.nix` derivation to ensure that the elf build dependencies are only included when building on Linux systems. This makes the package more portable and avoids unnecessary dependencies on other platforms.

Platform-specific dependency handling:

* [`encore.nix`](diffhunk://#diff-0298b842f42dca48278e39d3e315088f8b4657642d813c4f99df64d2e4a66098L25-R29): Changed `nativeBuildInputs` and `buildInputs` to use `lib.optionals stdenv.isLinux`, so that `autoPatchelfHook`, `stdenv.cc.cc.lib`, and `libtiff` are only included on Linux.