### PR TITLE
feat: use pkgs.stdenv.hostPlatform.system

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,12 @@ Import `encore.packages.default` into your nixos configuration
 ```nix
 # Home manager
 home.packages = [
-  inputs.encore.packages.${pkgs.system}.encore
+  inputs.encore.packages.${pkgs.stdenv.hostPlatform.system}.encore
 ];
 
 # NixOS configuration
 environment.systemPackages = [
-  inputs.encore.packages.${pkgs.system}.encore
+  inputs.encore.packages.${pkgs.stdenv.hostPlatform.system}.encore
 ];
 ```
 

--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,7 @@
 
       homeModules.default = { pkgs, ... } @ args:
         import ./hm-module.nix ({
-          inherit (self.packages.${pkgs.system}) encore;
+          inherit (self.packages.${pkgs.stdenv.hostPlatform.system}) encore;
         }
         // args);
     };


### PR DESCRIPTION
pkgs.system was deprecated a while ago and every time that I rebuild I have these logs

<img width="999" height="165" alt="image" src="https://github.com/user-attachments/assets/371f919b-e805-468f-8648-234e320ebcc0" />
