### PR TITLE
Build Encore from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # :snowflake: encore-flake
 
-A flake for simplifying installation of the released encore binaries on nix systems.
+A flake for simplifying installation of Encore on nix systems.
 
 Try it out by simply running
 
@@ -39,6 +39,23 @@ home.packages = [
 environment.systemPackages = [
   inputs.encore.packages.${pkgs.stdenv.hostPlatform.system}.encore
 ];
+```
+
+`encore` builds from source. `encore-bin` keeps installing the released binaries.
+
+### Applying patches
+
+The source package accepts patches through `override`:
+
+```nix
+let
+  encore = inputs.encore.packages.${pkgs.stdenv.hostPlatform.system}.encore;
+in
+encore.override {
+  patches = [
+    ./patches/my-encore-change.patch
+  ];
+}
 ```
 
 ### In a Development Shell
@@ -100,6 +117,8 @@ and use the `programs.encore` options
   };
 }
 ```
+
+Set `programs.encore.package` to `encore-bin` to use the released binaries.
 
 You can then keep it up to date by running
 

--- a/components/cli.nix
+++ b/components/cli.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  buildGoModule,
+  src,
+  sourceRelease,
+}:
+buildGoModule {
+  pname = "encore-cli";
+  version = sourceRelease.version;
+  inherit src;
+
+  vendorHash = sourceRelease.vendorHash;
+
+  postPatch = ''
+    mkdir -p cmd/encore-napi-defs
+    cp ${./generate-napi-defs.go} cmd/encore-napi-defs/main.go
+  '';
+
+  subPackages = [
+    "cli/cmd/encore"
+    "cli/cmd/git-remote-encore"
+    "cli/cmd/tsbundler-encore"
+    "cmd/encore-napi-defs"
+  ];
+
+  tags = [ "netgo" ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X=encr.dev/internal/version.Version=v${sourceRelease.version}"
+  ];
+
+  doCheck = false;
+
+  meta = {
+    description = "Encore command-line binaries";
+    homepage = "https://encore.dev";
+    license = lib.licenses.mpl20;
+    mainProgram = "encore";
+  };
+}

--- a/components/encore-go.nix
+++ b/components/encore-go.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  fetchFromGitHub,
+  fetchurl,
+  go_1_26,
+  sourceRelease,
+  encoreGoSrc ? fetchFromGitHub {
+    owner = "encoredev";
+    repo = "go";
+    rev = sourceRelease.encoreGo.rev;
+    hash = sourceRelease.encoreGo.sourceHash;
+  },
+  goSrc ? fetchurl {
+    url = "https://go.dev/dl/go${sourceRelease.encoreGo.version}.src.tar.gz";
+    hash = sourceRelease.encoreGo.goSourceHash;
+  },
+}:
+(go_1_26.overrideAttrs (old: {
+  pname = "encore-go";
+  version = "${sourceRelease.encoreGo.version}-encore";
+  src = goSrc;
+
+  patches = (old.patches or [ ]) ++ [
+    "${encoreGoSrc}/patches/cover_patch.diff"
+    "${encoreGoSrc}/patches/net_patch.diff"
+    "${encoreGoSrc}/patches/runtime_patch.diff"
+    "${encoreGoSrc}/patches/testing_patch.diff"
+    "${encoreGoSrc}/patches/version_patch.diff"
+  ];
+
+  postPatch = (old.postPatch or "") + ''
+    cp -R ${encoreGoSrc}/overlay/. .
+    chmod -R u+w .
+  '';
+
+  env = (old.env or { }) // {
+    CGO_ENABLED = 0;
+    GOROOT_FINAL = "/encore";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/encore-go $out/bin
+    cp -a bin pkg src lib misc api doc go.env VERSION $out/encore-go
+    ln -s ../encore-go/bin/go $out/bin/go
+
+    runHook postInstall
+  '';
+
+  passthru = (old.passthru or { }) // {
+    inherit encoreGoSrc goSrc;
+  };
+
+  meta = old.meta // {
+    description = "Encore Go toolchain built from source";
+    homepage = "https://github.com/encoredev/go";
+    license = lib.licenses.bsd3;
+    mainProgram = "go";
+  };
+}))

--- a/components/generate-napi-defs.go
+++ b/components/generate-napi-defs.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"flag"
+	"log"
+
+	"encr.dev/pkg/encorebuild/gentypedefs"
+)
+
+func main() {
+	version := flag.String("version", "", "Encore version")
+	input := flag.String("input", "", "Type definition input")
+	dtsOutput := flag.String("dts-output", "", "TypeScript declaration output")
+	cjsOutput := flag.String("cjs-output", "", "CommonJS wrapper output")
+	flag.Parse()
+
+	err := gentypedefs.Generate(gentypedefs.Config{
+		ReleaseVersion: *version,
+		TypeDefFile:    *input,
+		DtsOutputFile:  *dtsOutput,
+		CjsOutputFile:  *cjsOutput,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/components/js-runtime-native.nix
+++ b/components/js-runtime-native.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  perl,
+  cmake,
+  protobuf,
+  src,
+  sourceRelease,
+}:
+rustPlatform.buildRustPackage {
+  pname = "encore-js-runtime-native";
+  version = sourceRelease.version;
+  inherit src;
+
+  cargoHash = sourceRelease.cargoHash;
+  cargoBuildFlags = [
+    "-p"
+    "encore-js-runtime"
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    perl
+    protobuf
+  ];
+
+  preBuild = ''
+    export TYPE_DEF_TMP_PATH="$TMPDIR/typedefs.ndjson"
+    export ENCORE_VERSION="v${sourceRelease.version}"
+    export ENCORE_WORKDIR="$TMPDIR"
+  '';
+
+  doCheck = false;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib $out/share/encore
+    cp target/${stdenv.hostPlatform.rust.rustcTarget}/release/libencore_js_runtime${stdenv.hostPlatform.extensions.sharedLibrary} \
+      $out/lib/encore-runtime.node
+    cp "$TMPDIR/typedefs.ndjson" $out/share/encore/
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Native module for the Encore JavaScript runtime";
+    homepage = "https://encore.dev";
+    license = lib.licenses.mpl20;
+  };
+}

--- a/components/runtime-go.nix
+++ b/components/runtime-go.nix
@@ -1,0 +1,26 @@
+{
+  lib,
+  stdenvNoCC,
+  src,
+  sourceRelease,
+}:
+stdenvNoCC.mkDerivation {
+  pname = "encore-runtime-go";
+  version = sourceRelease.version;
+  inherit src;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/runtimes
+    cp -r runtimes/go $out/runtimes/
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Encore Go runtime sources";
+    homepage = "https://encore.dev";
+    license = lib.licenses.mpl20;
+  };
+}

--- a/components/runtime-js.nix
+++ b/components/runtime-js.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  buildNpmPackage,
+  callPackage,
+  src,
+  sourceRelease,
+  cli,
+  jsNative ? callPackage ./js-runtime-native.nix {
+    inherit src sourceRelease;
+  },
+}:
+buildNpmPackage {
+  pname = "encore-runtime-js";
+  version = sourceRelease.version;
+  inherit src;
+
+  sourceRoot = "${src.name}/runtimes/js/encore.dev";
+  npmDepsHash = sourceRelease.npmDepsHash;
+
+  nativeBuildInputs = [ cli ];
+
+  preBuild = ''
+    mkdir -p internal/runtime/napi
+    encore-napi-defs \
+      -version "v${sourceRelease.version}" \
+      -input ${jsNative}/share/encore/typedefs.ndjson \
+      -dts-output internal/runtime/napi/napi.d.cts \
+      -cjs-output internal/runtime/napi/napi.cjs
+  '';
+
+  postBuild = ''
+    ./node_modules/.bin/tsc-esm-fix --target=dist
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/runtimes
+    cp -r ${src}/runtimes/js $out/runtimes/
+    chmod -R u+w $out/runtimes/js
+    rm -rf $out/runtimes/js/encore.dev/dist
+    cp -r dist $out/runtimes/js/encore.dev/
+    mkdir -p $out/runtimes/js/encore.dev/internal/runtime
+    cp -r internal/runtime/napi $out/runtimes/js/encore.dev/internal/runtime/
+    cp ${jsNative}/lib/encore-runtime.node $out/runtimes/js/
+
+    runHook postInstall
+  '';
+
+  passthru = {
+    inherit jsNative;
+  };
+
+  meta = {
+    description = "Encore JavaScript runtime";
+    homepage = "https://encore.dev";
+    license = lib.licenses.mpl20;
+  };
+}

--- a/components/tsparser.nix
+++ b/components/tsparser.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  rustPlatform,
+  protobuf,
+  src,
+  sourceRelease,
+}:
+rustPlatform.buildRustPackage {
+  pname = "encore-tsparser";
+  version = sourceRelease.version;
+  inherit src;
+
+  cargoHash = sourceRelease.cargoHash;
+  cargoBuildFlags = [
+    "-p"
+    "encore-tsparser"
+    "--bin"
+    "tsparser-encore"
+  ];
+
+  nativeBuildInputs = [
+    protobuf
+    rustPlatform.bindgenHook
+  ];
+
+  ENCORE_VERSION = "v${sourceRelease.version}";
+
+  doCheck = false;
+
+  meta = {
+    description = "Encore TypeScript parser";
+    homepage = "https://encore.dev";
+    license = lib.licenses.mpl20;
+    mainProgram = "tsparser-encore";
+  };
+}

--- a/encore-bin.nix
+++ b/encore-bin.nix
@@ -1,0 +1,67 @@
+{
+  stdenv,
+  lib,
+  fetchurl,
+  autoPatchelfHook,
+  libtiff,
+}:
+let
+  release = import ./release.nix;
+in
+stdenv.mkDerivation rec {
+  pname = "encore-bin";
+  version = release.version;
+  system =
+    {
+      "x86_64-linux" = "linux_amd64";
+      "x86_64-darwin" = "darwin_amd64";
+      "aarch64-linux" = "linux_arm64";
+      "aarch64-darwin" = "darwin_arm64";
+    }
+    .${stdenv.targetPlatform.system};
+
+  checksum = release.checksums.${system};
+
+  src = fetchurl {
+    url = "https://d2f391esomvqpi.cloudfront.net/encore-${version}-${system}.tar.gz";
+    sha256 = checksum;
+  };
+
+  dontBuild = true;
+
+  nativeBuildInputs = lib.optionals stdenv.isLinux [
+    autoPatchelfHook
+  ];
+
+  buildInputs = lib.optionals stdenv.isLinux [
+    stdenv.cc.cc.lib
+    libtiff
+  ];
+
+  unpackPhase = ''
+    tar -C ./ -xzf ${src}
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mkdir -p $out/runtimes
+    mkdir -p $out/encore-go
+
+    cp -r ./bin/* $out/bin/
+    cp -r ./runtimes/* $out/runtimes/
+    cp -r ./encore-go/* $out/encore-go/
+  '';
+
+  meta = {
+    description = "Encore CLI distributed as upstream release binaries";
+    homepage = "https://encore.dev";
+    license = lib.licenses.mpl20;
+    mainProgram = "encore";
+    platforms = [
+      "x86_64-linux"
+      "x86_64-darwin"
+      "aarch64-linux"
+      "aarch64-darwin"
+    ];
+  };
+}

--- a/encore.nix
+++ b/encore.nix
@@ -1,59 +1,81 @@
-{ stdenv, lib, fetchurl, autoPatchelfHook, libtiff }:
-let
-  release = import ./release.nix;
-in
-stdenv.mkDerivation rec
 {
+  lib,
+  stdenvNoCC,
+  applyPatches,
+  fetchFromGitHub,
+  callPackage,
+  sourceRelease ? import ./source-release.nix,
+  encoreSrc ? fetchFromGitHub {
+    owner = "encoredev";
+    repo = "encore";
+    rev = "v${sourceRelease.version}";
+    hash = sourceRelease.sourceHash;
+  },
+  patches ? [ ],
+  patchedSrc ? applyPatches {
+    name = "encore-${sourceRelease.version}-source";
+    src = encoreSrc;
+    inherit patches;
+  },
+  cli ? callPackage ./components/cli.nix {
+    src = patchedSrc;
+    inherit sourceRelease;
+  },
+  tsparser ? callPackage ./components/tsparser.nix {
+    src = patchedSrc;
+    inherit sourceRelease;
+  },
+  runtimeGo ? callPackage ./components/runtime-go.nix {
+    src = patchedSrc;
+    inherit sourceRelease;
+  },
+  runtimeJs ? callPackage ./components/runtime-js.nix {
+    src = patchedSrc;
+    inherit sourceRelease cli;
+  },
+  encoreGo ? callPackage ./components/encore-go.nix {
+    inherit sourceRelease;
+  },
+}:
+stdenvNoCC.mkDerivation {
   pname = "encore";
-  version = release.version;
-  system = {
-    "x86_64-linux" = "linux_amd64";
-    "x86_64-darwin" = "darwin_amd64";
-    "aarch64-linux" = "linux_arm64";
-    "aarch64-darwin" = "darwin_arm64";
-  }.${stdenv.targetPlatform.system};
+  version = sourceRelease.version;
 
-  checksum = release.checksums.${system};
-
-  src = fetchurl {
-    url = "https://d2f391esomvqpi.cloudfront.net/${pname}-${version}-${system}.tar.gz";
-    sha256 = checksum;
-  };
-
-  dontBuild = true;
-
-  nativeBuildInputs = lib.optionals stdenv.isLinux [
-    autoPatchelfHook
-  ];
-
-  buildInputs = lib.optionals stdenv.isLinux [
-    stdenv.cc.cc.lib
-    libtiff
-  ];
-
-  unpackPhase = ''
-    tar -C ./ -xzf ${src}
-  '';
+  dontUnpack = true;
 
   installPhase = ''
-    mkdir -p $out/bin
-    mkdir -p $out/runtimes
-    mkdir -p $out/encore-go
+    runHook preInstall
 
-    cp -r ./bin/* $out/bin/
-    cp -r ./runtimes/* $out/runtimes/
-    cp -r ./encore-go/* $out/encore-go/
+    mkdir -p $out/bin $out/runtimes
+    cp ${cli}/bin/encore $out/bin/
+    cp ${cli}/bin/git-remote-encore $out/bin/
+    cp ${cli}/bin/tsbundler-encore $out/bin/
+    cp ${tsparser}/bin/tsparser-encore $out/bin/
+    cp -r ${runtimeGo}/runtimes/go $out/runtimes/
+    cp -r ${runtimeJs}/runtimes/js $out/runtimes/
+    cp -r ${encoreGo}/encore-go $out/
+
+    runHook postInstall
   '';
 
+  passthru = {
+    inherit encoreSrc patchedSrc;
+    components = {
+      inherit
+        cli
+        tsparser
+        runtimeGo
+        runtimeJs
+        encoreGo
+        ;
+    };
+  };
+
   meta = {
-    description = "encore cli";
+    description = "Encore CLI built from source";
     homepage = "https://encore.dev";
     license = lib.licenses.mpl20;
-    platforms = [
-      "x86_64-linux"
-      "x86_64-darwin"
-      "aarch64-linux"
-      "aarch64-darwin"
-    ];
+    mainProgram = "encore";
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };
 }

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1728538411,
-        "narHash": "sha256-f0SBJz1eZ2yOuKUr5CA9BHULGXVSn6miBuUWdTyhUhU=",
+        "lastModified": 1784963784,
+        "narHash": "sha256-IZAjgNI19TdwYus6QUIMvU0cw0vWVb/5oYwpyxQXL1E=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b69de56fac8c2b6f8fd27f2eca01dcda8e0a4221",
+        "rev": "38affae6a5768f9b61f81355c7558ee971b2afb1",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "nix flake that wraps the released encore binaries";
+  description = "nix flake that packages Encore from source and released binaries";
 
   inputs.nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
 
@@ -11,7 +11,6 @@
     let
       eachSystem = nixpkgs.lib.genAttrs [
         "x86_64-linux"
-        "x86_64-darwin"
         "aarch64-linux"
         "aarch64-darwin"
       ];
@@ -19,10 +18,18 @@
     {
       packages = eachSystem (system:
         let
-          encore = nixpkgs.legacyPackages.${system}.callPackage ./encore.nix { };
+          pkgs = nixpkgs.legacyPackages.${system};
+          encoreBin = pkgs.callPackage ./encore-bin.nix { };
+          encore = pkgs.callPackage ./encore.nix { };
         in
         {
-          encore = encore;
+          inherit encore;
+          encore-bin = encoreBin;
+          encore-cli = encore.components.cli;
+          encore-tsparser = encore.components.tsparser;
+          encore-runtime-go = encore.components.runtimeGo;
+          encore-runtime-js = encore.components.runtimeJs;
+          encore-go = encore.components.encoreGo;
           default = encore;
         });
 
@@ -30,7 +37,7 @@
 
       homeModules.default = { pkgs, ... } @ args:
         import ./hm-module.nix ({
-          inherit (self.packages.${pkgs.stdenv.hostPlatform.system}) encore;
+          encore = self.packages.${pkgs.stdenv.hostPlatform.system}.default;
         }
         // args);
     };

--- a/hm-module.nix
+++ b/hm-module.nix
@@ -11,6 +11,12 @@ in
   options.programs.encore = {
     enable = mkEnableOption "Enable Encore CLI";
 
+    package = mkOption {
+      type = types.package;
+      default = encore;
+      description = "Encore package to install.";
+    };
+
     settings = {
       browser = mkOption {
         type = types.enum [ "auto" "never" "always" ];
@@ -25,7 +31,7 @@ in
 
   config = mkIf cfg.enable {
     home.packages = [
-      encore
+      cfg.package
     ];
 
     xdg.configFile."encore/config".source = (pkgs.formats.toml { }).generate "encore-config" {

--- a/source-release.nix
+++ b/source-release.nix
@@ -1,0 +1,13 @@
+{
+  version = "1.57.13";
+  sourceHash = "sha256-8kFszs0g1GO/eK2bPRF+X3PyjbH86UzInVoItrsCBhU=";
+  vendorHash = "sha256-XrfujphhmYH6UPplNmCgnYpvmZgLHWtET9HlFuHz7oE=";
+  cargoHash = "sha256-VKQPmOJZKAukhLj3n/0cztgwaieMGJeeUaQpfQhlgNA=";
+  npmDepsHash = "sha256-LMaxSamGqgi6QlRaoMQVkfT5AddPgnlQggpC9hMe3/0=";
+  encoreGo = {
+    version = "1.26.5";
+    rev = "8472afa3747a9f01bc5b979e7555c3055b4bb65d";
+    sourceHash = "sha256-9Joz7bruAxZeMx2jJrvK7EqPMF923lR8sqlrq8EE+aM=";
+    goSourceHash = "sha256-SVvkvIcXasVnOS5bQRar2YRm0z17SdQedkzMaXay3EI=";
+  };
+}


### PR DESCRIPTION
`encore-flake` now builds Encore from source instead of packaging only the released Encore binaries.

Specifically, it:

* builds the Encore CLI, TypeScript parser, Go runtime, and JavaScript runtime from pinned sources
* builds Encore Go from pinned Go sources with Encore's patch set
* exposes component packages and a shared patchable source tree for downstream overrides
* keeps the released binaries available as `encore-bin`
* lets Home Manager users choose between the source and binary packages

## Why

Building Encore from source allows downstream users to patch and validate individual components without depending on release archives.

As part of this change:

* **`encore`** now refers to the source-built package
* **`encore-bin`** continues to package the upstream release binaries

## Compatibility

* Removed x86_64-darwin support because nixpkgs has deprecated the platform and plans to stop building packages for it in Nixpkgs 26.11. See the [Nixpkgs release notes](https://nixos.org/manual/nixpkgs/stable/release-notes).

## Upstreaming

I think these derivations should eventually live in the main Encore repository.

The current non-Nix build process can be somewhat tedious for new contributors. Keeping these definitions alongside Encore would make it easier to build the project, test local changes, and contribute using the same reproducible toolchain.

An external flake must fetch pinned revisions with fixed hashes, so it cannot directly represent changes in a contributor's working tree. Moving these definitions upstream would remove that limitation and allow contributors to build the active checkout instead of waiting for a release artifact.

## Release Maintenance

The automation for updating source-release.nix is intentionally not included in this PR, as I think it's part of a private workflow.

The existing release process can be extended to update it automatically when publishing a new Encore release.

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/50605859-35de-4073-9d98-5479c95e6498" />

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/encoredev/codesmith/encore-flake/pr/8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787702519&installation_model_id=427204&pr_number=8&repository=encoredev%2Fencore-flake&return_to=https%3A%2F%2Fgithub.com%2Fencoredev%2Fencore-flake%2Fpull%2F8&signature=c672e1006d480ba7e4512e78f6bfbdde1fbb6dd4028c89429e2b9e050d32ad3b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->